### PR TITLE
Updated createdAt data type to INT

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -11,7 +11,7 @@ type Raft @entity {
   specs: [BadgeSpec!]! @derivedFrom(field: "raft")
   totalSpecsCount: Int!
   totalBadgesCount: Int!
-  createdAt: BigInt!
+  createdAt: Int!
   createdBy: String!
 }
 
@@ -25,7 +25,7 @@ type BadgeSpec @entity {
   raft: Raft!
   badges: [Badge!]! @derivedFrom(field: "spec")
   totalBadgesCount: Int!
-  createdAt: BigInt!
+  createdAt: Int!
   createdBy: String!
 }
 
@@ -34,6 +34,6 @@ type Badge @entity {
   from: Bytes!
   owner: Bytes!
   spec: BadgeSpec!
-  createdAt: BigInt!
+  createdAt: Int!
   burnedAt: BigInt
 }

--- a/src/badges/index.ts
+++ b/src/badges/index.ts
@@ -17,7 +17,7 @@ export function handleBadgeMinted(badgeId: string, event: BadgeTransfer): void {
   badge.from = from;
   badge.owner = to;
   badge.spec = specID;
-  badge.createdAt = timestamp;
+  badge.createdAt = timestamp.toI32();
   badge.save();
 
   const spec = BadgeSpec.load(specID);
@@ -33,7 +33,7 @@ export function handleBadgeMinted(badgeId: string, event: BadgeTransfer): void {
     } else {
       log.error(
         'handleBadgeMinted: RaftID {} not found. Raft entity was not updated with totalBadgesCount',
-        [raftID]
+        [raftID],
       );
     }
   } else {
@@ -50,7 +50,7 @@ export function handleBadgeBurned(badgeId: string, event: BadgeTransfer): void {
   } else {
     log.error(
       'handleBadgeBurned: Badge {} not found. Badge entity was not updated with burnedAtTimestamp',
-      [badgeId]
+      [badgeId],
     );
   }
 }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -38,7 +38,7 @@ export function handleRaftTransfer(event: RaftTransfer): void {
     raft.tokenId = tokenId;
     raft.totalBadgesCount = 0;
     raft.totalSpecsCount = 0;
-    raft.createdAt = timestamp;
+    raft.createdAt = timestamp.toI32();
     raft.createdBy = event.params.from.toHexString();
 
     const raftContract = RaftContract.bind(event.address);
@@ -79,7 +79,7 @@ export function handleSpecCreated(event: SpecCreated): void {
   let spec = new BadgeSpec(cid);
   spec.uri = uri;
   spec.raft = raftID;
-  spec.createdAt = timestamp;
+  spec.createdAt = timestamp.toI32();
   spec.totalBadgesCount = 0;
   spec.createdBy = createdBy;
 


### PR DESCRIPTION
BigInts automatically were getting converted to strings. @dsh-otter tagging you here since this affects your workflow. I updated/deploy Goerli subgraph already. (Also to reindex the missed IPFS events). 